### PR TITLE
Record outbound phone calls by default

### DIFF
--- a/OpenVBX/controllers/twiml.php
+++ b/OpenVBX/controllers/twiml.php
@@ -352,6 +352,7 @@ class Twiml extends MY_Controller {
 			$options = array(
 				'action' => site_url("twiml/dial_status").'?'.http_build_query(compact('to')),
 				'callerId' => $callerid,
+				'record' => 'record-from-ringing',
 				'timeout' => $this->vbx_settings->get('dial_timeout', $this->tenant->id)
 			);
 			


### PR DESCRIPTION
all outbound calls will generate a recording.

I saw you wanted this configured per number, that can come in the future as we can store this as a flag on the number table.